### PR TITLE
Depend on DAISIE v3.2.1, not v3.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 Imports: 
-    DAISIE (>= 3.2.0)
+    DAISIE (>= 3.2.1)
 Suggests: 
     testthat,
     covr,
@@ -24,5 +24,5 @@ Suggests:
     testit,
     utils
 Remotes:
-     rsetienne/DAISIE@v3.2.0
+     rsetienne/DAISIE@v3.2.1
 VignetteBuilder: knitr


### PR DESCRIPTION
I suspect a hard dependency on `DAISIE` v3.2.0 in the Remotes section of `DESCRITPION` is forcing GHA to replace the installed v3.2.1 `DAISIE` installation with v3.2.0 as can be seen here: https://github.com/tece-lab/DAISIEutils/runs/2256945325?check_suite_focus=true#step:8:18

This then causes the check of `DAISIEutils` to fail, as it requires >= v3.2.1. I've tried rearranging the order of the dependencies in `DAISIEutils`, but it didn't solve the problem. Could you please accept this PR to see if it will do the job?